### PR TITLE
Obtaining an API key: new instructions

### DIFF
--- a/docs/nonprofit-search.md
+++ b/docs/nonprofit-search.md
@@ -20,8 +20,8 @@ We currently have three endpoints:
 
 ## Authentication
 
-To use the API endpoints you need to get a public API key to send along with
-requests, you can create an API key at [every.org/developer](https://www.every.org/developer).
+To use API endpoints, you need to get a public API key to send along with
+requests - to generate API keys go to our [API key dashboard](https://www.every.org/developer).
 
 This can be used client side or server side, the api key can be made public— it
 is not a secret, though we reserve the right to block api keys at any time if

--- a/docs/nonprofit-search.md
+++ b/docs/nonprofit-search.md
@@ -20,10 +20,8 @@ We currently have three endpoints:
 
 ## Authentication
 
-To use API endpoints, you need to get a public API key to send along with
-requests - please request one by email
-[partners@every.org](mailto:partners@every.org) and explaining your use case and
-expected traffic.
+To use the API endpoints you need to get a public API key to send along with
+requests, you can create an API key at [every.org/developer](https://www.every.org/developer).
 
 This can be used client side or server side, the api key can be made public— it
 is not a secret, though we reserve the right to block api keys at any time if


### PR DESCRIPTION
Updates the instructions to get an API key from the old manual email request to the self-served dashboard based.