### PR TITLE
Donation webhooks: add from fundraiser documentation

### DIFF
--- a/docs/webhooks/_request-format.mdx
+++ b/docs/webhooks/_request-format.mdx
@@ -46,7 +46,7 @@ properties:
   - A publicly available comment for this donation written by the donor showing at every.org that can be shared.
 - `privateNote: <string | undefined>`
   - A private note for the nonprofit written by the donor.
-- `fromFundraiser: <object | null>`
+- `fromFundraiser: <object | undefined>`
   - An object with the following properties:
     - `id: <string>`
       - The fundraiser's id.

--- a/docs/webhooks/_request-format.mdx
+++ b/docs/webhooks/_request-format.mdx
@@ -46,6 +46,16 @@ properties:
   - A publicly available comment for this donation written by the donor showing at every.org that can be shared.
 - `privateNote: <string | undefined>`
   - A private note for the nonprofit written by the donor.
+- `fromFundraiser: <object | null>`
+  - An object with the following properties:
+    - `id: <string>`
+      - The fundraiser's id.
+    - `title: <string>`
+      - The fundraiser's title.
+    - `slug: <string>`
+      - The slug that identifies the fundraiser. [Every.org](http://every.org)
+        uses the slug to construct the nonprofit's URL as follows:
+        `every.org/<toNonprofit.slug>/f/<fromFundraiser.slug>`
 
 Example request body:
 


### PR DESCRIPTION
Adds the `fromFundraiser` field documentation in webhook notifications.